### PR TITLE
Wrap button text in a FittedBox to allow it to scale down if needed.

### DIFF
--- a/lib/src/button_builder.dart
+++ b/lib/src/button_builder.dart
@@ -108,10 +108,11 @@ class SignInButtonBuilder extends StatelessWidget {
         child: _getIconOrImage(),
       );
     }
+
+    final double buttonWidth = width ?? 220;
+
     return Container(
-      constraints: BoxConstraints(
-        maxWidth: width ?? 220,
-      ),
+      constraints: BoxConstraints(maxWidth: buttonWidth),
       child: Center(
         child: Row(
           children: <Widget>[
@@ -122,12 +123,20 @@ class SignInButtonBuilder extends StatelessWidget {
                   ),
               child: _getIconOrImage(),
             ),
-            Text(
-              text,
-              style: TextStyle(
-                color: textColor,
-                fontSize: fontSize,
-                backgroundColor: const Color.fromRGBO(0, 0, 0, 0),
+            Container(
+              constraints: BoxConstraints(
+                maxWidth: buttonWidth - 50,
+              ),
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  text,
+                  style: TextStyle(
+                    color: textColor,
+                    fontSize: fontSize,
+                    backgroundColor: const Color.fromRGBO(0, 0, 0, 0),
+                  ),
+                ),
               ),
             ),
           ],


### PR DESCRIPTION
This solves #3 by scaling the text down if needed.

Assumes that the icon/image is never more than 50 in width, which seems to work well with Google and Apple, but haven't tried all of them. Not sure if there's a better way to know that.