### PR TITLE
refactor: Change return type from nullable to widget type only

### DIFF
--- a/lib/src/button_builder.dart
+++ b/lib/src/button_builder.dart
@@ -137,9 +137,9 @@ class SignInButtonBuilder extends StatelessWidget {
   }
 
   /// Get the icon or image widget
-  Widget? _getIconOrImage() {
+  Widget _getIconOrImage() {
     if (image != null) {
-      return image;
+      return image!;
     }
     return Icon(
       icon,


### PR DESCRIPTION
Thank you for creating a very nice library

Thanks to this library, the development period was very short.

What I found is very detailed
There was a part that was a nullable type, so I changed it to a widget type.